### PR TITLE
Fix (onAjax): Empty callback resets the variable

### DIFF
--- a/jquery.tabledit.js
+++ b/jquery.tabledit.js
@@ -233,7 +233,7 @@ if (typeof jQuery === 'undefined') {
         // In onAjax() it is possible to modify the document sent in ajax request, e.g. adding additional information required by server, or do formatting / restructing of document to be sent.
         if (result === false) {
           return false;
-        } else {
+        } else if(result !== undefined) {
           serialize = result;
         }
 


### PR DESCRIPTION
Empty callback return 'undefined' and after that the variable 'serialize' is 'undefined'  too